### PR TITLE
Automatic Mitogen patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ ansible-galaxy collection install -r requirements.yml
 ## Usage
 Add to your ansible.cfg
 ```
-strategy_plugins = psvmcc.mitogen
 strategy = psvmcc.mitogen.mitogen_linear
 ```
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: ">=2.14"

--- a/plugins/strategy/mitogen.py
+++ b/plugins/strategy/mitogen.py
@@ -1,1 +1,4 @@
-from ansible_mitogen.plugins.strategy.mitogen import *
+from . import patching
+
+with patching.patch_version():
+    from ansible_mitogen.plugins.strategy.mitogen import *

--- a/plugins/strategy/mitogen_free.py
+++ b/plugins/strategy/mitogen_free.py
@@ -1,1 +1,4 @@
-from ansible_mitogen.plugins.strategy.mitogen_free import *
+from patching import patch_version
+
+with patch_version():
+    from ansible_mitogen.plugins.strategy.mitogen_free import *

--- a/plugins/strategy/mitogen_free.py
+++ b/plugins/strategy/mitogen_free.py
@@ -1,4 +1,4 @@
-from patching import patch_version
+from . import patching
 
-with patch_version():
+with patching.patch_version():
     from ansible_mitogen.plugins.strategy.mitogen_free import *

--- a/plugins/strategy/mitogen_host_pinned.py
+++ b/plugins/strategy/mitogen_host_pinned.py
@@ -1,4 +1,4 @@
-from patching import patch_version
+from . import patching
 
-with patch_version():
+with patching.patch_version():
     from ansible_mitogen.plugins.strategy.mitogen_host_pinned import *

--- a/plugins/strategy/mitogen_host_pinned.py
+++ b/plugins/strategy/mitogen_host_pinned.py
@@ -1,1 +1,4 @@
-from ansible_mitogen.plugins.strategy.mitogen_host_pinned import *
+from patching import patch_version
+
+with patch_version():
+    from ansible_mitogen.plugins.strategy.mitogen_host_pinned import *

--- a/plugins/strategy/mitogen_linear.py
+++ b/plugins/strategy/mitogen_linear.py
@@ -1,1 +1,4 @@
-from ansible_mitogen.plugins.strategy.mitogen_linear import *
+from patching import patch_version
+
+with patch_version():
+    from ansible_mitogen.plugins.strategy.mitogen_linear import *

--- a/plugins/strategy/mitogen_linear.py
+++ b/plugins/strategy/mitogen_linear.py
@@ -1,4 +1,4 @@
-from patching import patch_version
+from . import patching
 
-with patch_version():
+with patching.patch_version():
     from ansible_mitogen.plugins.strategy.mitogen_linear import *

--- a/plugins/strategy/patching.py
+++ b/plugins/strategy/patching.py
@@ -1,0 +1,41 @@
+from contextlib import ContextDecorator
+import os
+
+
+def loaders_path():
+    import ansible_mitogen
+
+    loaders_path = os.path.join(os.path.dirname(ansible_mitogen.__file__), "loaders.py")
+    return loaders_path
+
+
+class patch_version(ContextDecorator):
+    ORIG_LINE = "ANSIBLE_VERSION_MAX = (2, 13)\n"
+    PATCH_LINE = "ANSIBLE_VERSION_MAX = (2, 15)\n"
+
+    def __enter__(self):
+        self.patched = False
+        self.lp = loaders_path()
+        self.lp_orig = self.lp + ".orig"
+
+        with open(self.lp) as f:
+            if not self.ORIG_LINE in f.read():
+                return self
+
+        if os.path.isfile(self.lp_orig):
+            return self
+
+        os.rename(self.lp, self.lp_orig)
+        self.patched = True
+        with open(self.lp_orig) as source:
+            with open(self.lp, "w") as dest:
+                for line in source.readlines():
+                    if line == "ANSIBLE_VERSION_MAX = (2, 13)\n":
+                        line = "ANSIBLE_VERSION_MAX = (2, 15)\n"
+                    dest.write(line)
+        return self
+
+    def __exit__(self, *exc):
+        if self.patched:
+            os.rename(self.lp_orig, self.lp)
+        return False


### PR DESCRIPTION
It's very unfortunate, that Mitogen does not release new version and keep Ansible version below currently supported.

Multiple experiments showed that mitogen (from current master) works more or less fine with fresh Ansible. There are few bad cases, but they are no more bad than before. Therefore, to use 'new mitogen with new Ansible' we need either fork Mitogen, or have a way to bypass version check.

This code implements former. It temporary patches mitogen loaders.py with higher version (`ANSIBLE_VERSION_MAX`), load it, and unpatches mitogen code back to original state.

It's dirty, and it's non-reinterable (do not run two ansibles in parallel from the same venv), but it allows to use Mitogen on newer Ansibles without additional magic involved.


I also remove 'strategy_plugins' from docs, as it's not needed, and set minimum requirements for ansible (in `runtime.yml`) to 2.14.